### PR TITLE
Fix conf base for child domains

### DIFF
--- a/certilib/main.py
+++ b/certilib/main.py
@@ -414,22 +414,22 @@ def main_list(args):
     )
 
     sids_resolver = SidsResolver(ldap_conn)
-
+    domain_root=".".join(args.userdomain.split(".")[-2:])
     if "ca" in args.classes:
         print("[*] Root CAs\n")
-        for cert in fetch_root_cas(ldap_conn, args.userdomain):
+        for cert in fetch_root_cas(ldap_conn, domain_root):
             print_cert(cert)
             print("")
 
             print("[*] Authority Information Access\n")
-            for cert in fetch_aia_cas(ldap_conn, args.userdomain):
+            for cert in fetch_aia_cas(ldap_conn, domain_root):
                 print_cert(cert)
                 print("")
 
 
     if "ntauth" in args.classes:
         print("[*] NtAuthCertificates - Certificates that enable authentication\n")
-        for cert in fetch_ntauthcertificates(ldap_conn, args.userdomain):
+        for cert in fetch_ntauthcertificates(ldap_conn, domain_root):
             print_cert(cert)
             print("")
 
@@ -439,7 +439,7 @@ def main_list(args):
         print("[*] Enrollment Services\n")
         enroll_services = list(fetch_enrollment_services(
             ldap_conn,
-            args.userdomain
+            domain_root
         ))
         for service in enroll_services:
             print_service(service)
@@ -449,14 +449,14 @@ def main_list(args):
     if "template" in args.classes:
         templates = list(fetch_templates(
             ldap_conn,
-            args.userdomain,
+            domain_root,
             temp_names=args.temp_name,
             ldap_filter=args.temp_filter,
         ))
         if not enroll_services:
             enroll_services = list(fetch_enrollment_services(
                 ldap_conn,
-                args.userdomain
+                domain_root
             ))
 
         for template in templates:


### PR DESCRIPTION
Hello, I had an issue while running the tool against ADCS on a child domain. This fix is working for me (on child and parent domains). Please find details below.

```
└─$ certi.py list north.sevenkingdoms.local/hodor:hodor --dc-ip 192.168.56.11             
Traceback (most recent call last):
  File "/home/kali/.local/bin/certi.py", line 8, in <module>
    sys.exit(main())
  File "/home/kali/.local/pipx/venvs/certi/lib/python3.10/site-packages/certilib/main.py", line 245, in main
    return main_list(args)
  File "/home/kali/.local/pipx/venvs/certi/lib/python3.10/site-packages/certilib/main.py", line 450, in main_list
    templates = list(fetch_templates(
  File "/home/kali/.local/pipx/venvs/certi/lib/python3.10/site-packages/certilib/main.py", line 651, in fetch_templates
    resp = search_ldap(
  File "/home/kali/.local/pipx/venvs/certi/lib/python3.10/site-packages/certilib/ldap.py", line 69, in search_ldap
    return ldap_conn.search(
  File "/home/kali/.local/pipx/venvs/certi/lib/python3.10/site-packages/impacket/ldap/ldap.py", line 350, in search
    raise LDAPSearchError(
impacket.ldap.ldap.LDAPSearchError: Error in searchRequest -> noSuchObject: 0000208D: NameErr: DSID-0310028C, problem 2001 (NO_OBJECT), data 0, best match of:
        'DC=north,DC=sevenkingdoms,DC=local'
```

The error is caused by the config base `conf_base = "CN=Configuration,{}".format(get_base_dn(domain))`, which should be containing the root domain and not the full child domain:

![image](https://user-images.githubusercontent.com/25101526/217037621-dfcd4a4f-f305-43e5-9b59-9ca94df2a64d.png)

Thanks!
